### PR TITLE
Add edition to Cargo.toml

### DIFF
--- a/src/week1/index.md
+++ b/src/week1/index.md
@@ -521,6 +521,7 @@ created when you used `cargo new`. Make it so your `Cargo.toml` looks like this:
 [package]
 name = "adder"
 version = "0.1.0"
+edition = "2021"
 
 [dependencies]
 sexp = "1.1.4"


### PR DESCRIPTION
As per the email. The default edition, 2015, requires `extern crate` and some other missing imports